### PR TITLE
Cross-sequence variable references

### DIFF
--- a/src/main/java/com/coreyd97/stepper/Stepper.java
+++ b/src/main/java/com/coreyd97/stepper/Stepper.java
@@ -18,10 +18,10 @@ public class Stepper implements IBurpExtender {
     public static IBurpExtenderCallbacks callbacks;
     public static IGsonProvider gsonProvider = new DefaultGsonProvider();
     private static Preferences preferences;
+    private static SequenceManager sequenceManager;
 
     private StateManager stateManager;
     private MessageProcessor messageProcessor;
-    private SequenceManager sequenceManager;
 
     public Stepper(){
         Stepper.instance = this;
@@ -38,6 +38,10 @@ public class Stepper implements IBurpExtender {
 
     public static Stepper getInstance() {
         return instance;
+    }
+
+    public static SequenceManager getSequenceManager(){
+        return sequenceManager;
     }
 
     @Override

--- a/src/main/java/com/coreyd97/stepper/step/Step.java
+++ b/src/main/java/com/coreyd97/stepper/step/Step.java
@@ -126,6 +126,8 @@ public class Step implements IMessageEditorController {
 //                if(result == JOptionPane.NO_OPTION) throw new SequenceCancelledException("Binary data, user cancelled.");
 //            }
             builtRequest = MessageProcessor.makeReplacementsForSingleSequence(requestWithoutReplacements, replacements);
+            HashMap<StepSequence, List<StepVariable>> allVariables = Stepper.instance.getSequenceManager().getRollingVariablesFromAllSequences();
+            builtRequest = MessageProcessor.makeReplacementsForAllSequences(builtRequest, allVariables);
         }else{
             builtRequest = Arrays.copyOf(requestWithoutReplacements, requestWithoutReplacements.length);
         }


### PR DESCRIPTION
This allows accessing variables (e.g. cookie set during login)
from other Sequences. Uses the same logic as the MessageProcessor.
SequenceManager made accessible by making it static.