### PR TITLE
Add option to disable warnings if message is unprocessable

### DIFF
--- a/src/main/java/com/coreyd97/stepper/Globals.java
+++ b/src/main/java/com/coreyd97/stepper/Globals.java
@@ -15,4 +15,5 @@ public class Globals {
     public static final String PREF_VARS_IN_SPIDER = "enableVarsInSpider";
     public static final String PREF_UPDATE_REQUEST_LENGTH = "updateRequestLength";
     public static final String PREF_ENABLE_SHORTCUT = "enableShortcut";
+    public static final String PREF_ENABLE_UNPROCESSABLE_WARNING = "enableUnprocessableWarning";
 }

--- a/src/main/java/com/coreyd97/stepper/MessageProcessor.java
+++ b/src/main/java/com/coreyd97/stepper/MessageProcessor.java
@@ -93,14 +93,15 @@ public class MessageProcessor implements IHttpListener {
                 HashMap<StepSequence, List<StepVariable>> allVariables = sequenceManager.getRollingVariablesFromAllSequences();
 
                 if(allVariables.size() > 0 && hasStepVariable(request)) {
-
-                    if(isUnprocessable(messageInfo.getRequest())){
+                    if(isUnprocessable(messageInfo.getRequest()) && Stepper.getPreferences().getSetting(Globals.PREF_ENABLE_UNPROCESSABLE_WARNING).equals(true)){
                         //If there's unicode issues, we're likely acting on binary data. Warn the user.
+                        //But only warn user if they did not disable this warning.
+                        //In some cases, especially if Stepper is used together with Param Miner, these warnings can popup often
                         int result = JOptionPane.showConfirmDialog(Stepper.getUI().getUiComponent(),
-                                "The request contains non UTF characters.\nStepper is able to make the replacements, " +
-                                        "but some of the binary data may be lost. Continue?",
-                                "Stepper Replacement Error", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-                        if(result == JOptionPane.NO_OPTION) return;
+                        "The request contains non UTF characters.\nStepper is able to make the replacements, " +
+                                "but some of the binary data may be lost. Continue?",
+                        "Stepper Replacement Error", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                        if(result == JOptionPane.NO_OPTION) return;  
                     }
 
                     try {

--- a/src/main/java/com/coreyd97/stepper/preferences/StepperPreferenceFactory.java
+++ b/src/main/java/com/coreyd97/stepper/preferences/StepperPreferenceFactory.java
@@ -64,5 +64,6 @@ public class StepperPreferenceFactory extends PreferenceFactory {
         prefs.registerSetting(Globals.PREF_VARS_IN_SCANNER, Boolean.class, true, Preferences.Visibility.GLOBAL);
         prefs.registerSetting(Globals.PREF_UPDATE_REQUEST_LENGTH, Boolean.class, true, Preferences.Visibility.GLOBAL);
         prefs.registerSetting(Globals.PREF_ENABLE_SHORTCUT, Boolean.class, true, Preferences.Visibility.GLOBAL);
+        prefs.registerSetting(Globals.PREF_ENABLE_UNPROCESSABLE_WARNING, Boolean.class, true, Preferences.Visibility.GLOBAL);
     }
 }

--- a/src/main/java/com/coreyd97/stepper/preferences/view/OptionsPanel.java
+++ b/src/main/java/com/coreyd97/stepper/preferences/view/OptionsPanel.java
@@ -36,6 +36,7 @@ public class OptionsPanel extends JPanel {
         ComponentGroup configGroup = new ComponentGroup(ComponentGroup.Orientation.VERTICAL, "Config");
         configGroup.addPreferenceComponent(preferences, Globals.PREF_UPDATE_REQUEST_LENGTH, "Automatically update the Content-Length header");
         configGroup.addPreferenceComponent(preferences, Globals.PREF_ENABLE_SHORTCUT, "Enable Shortcut (Ctrl+Shift+G)");
+        configGroup.addPreferenceComponent(preferences, Globals.PREF_ENABLE_UNPROCESSABLE_WARNING, "Enable warning if non UTF-8 character in request");
 
         ComponentGroup toolEnabledGroup = new ComponentGroup(ComponentGroup.Orientation.VERTICAL, "Allow Variables Usage");
         JCheckBox allToolsCheckbox = toolEnabledGroup.addPreferenceComponent(preferences, Globals.PREF_VARS_IN_ALL_TOOLS, "All Tools");


### PR DESCRIPTION
Hi @CoreyD97,

when using Stepper in conjunction with Param Miner I sometimes had the issue that the warning dialog of an unprocessable message keeps popping up. As the dialog stops you from interacting with anything else and clicking yes everytime disrupts any other work, I added an option to disable this warning and process the message regardless.