### PR TITLE
Add sequence args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ releases/
 gradle-app.setting
 .gradletasknamecache
 .git
+bin

--- a/src/main/java/com/coreyd97/stepper/MessageProcessor.java
+++ b/src/main/java/com/coreyd97/stepper/MessageProcessor.java
@@ -31,6 +31,9 @@ public class MessageProcessor implements IHttpListener {
     public static final Pattern EXECUTE_AFTER_HEADER_PATTERN = Pattern.compile("^" + EXECUTE_AFTER_REGEX + "$", Pattern.CASE_INSENSITIVE);
     public static final String STEPPER_IGNORE_HEADER = "X-Stepper-Ignore";
     public static final Pattern STEPPER_IGNORE_PATTERN = Pattern.compile("^"+STEPPER_IGNORE_HEADER, Pattern.CASE_INSENSITIVE);
+    public static final Pattern STEPPER_SEQUENCE_NAME_PATTERN = Pattern.compile("^([^:]+)(?::?)", Pattern.CASE_INSENSITIVE);
+    public static final Pattern VARIABLE_LIST_PATTERN = Pattern.compile("\\w+(:\\s*(?<variables>.+))?", Pattern.CASE_INSENSITIVE);
+    public static final Pattern VARIABLE_PATTERN = Pattern.compile("(?<key>\\w+)=(?<value>[^;]+);?", Pattern.CASE_INSENSITIVE);
 
     public MessageProcessor(SequenceManager sequenceManager, Preferences preferences){
         this.sequenceManager = sequenceManager;
@@ -63,18 +66,21 @@ public class MessageProcessor implements IHttpListener {
             if(messageIsRequest){
                 byte[] request = messageInfo.getRequest();
                 System.out.println("Request: " + messageInfo.getRequest());
-                List<StepSequence> preExecSequences = extractExecSequencesFromRequest(requestInfo, EXECUTE_BEFORE_HEADER_PATTERN);
+                List<RequestSequenceInformation> preExecSequences = extractExecSequencesFromRequest(requestInfo, EXECUTE_BEFORE_HEADER_PATTERN);
                 if(preExecSequences.size() > 0){
                     //Remove the headers from the request
                     request = removeHeaderMatchingPattern(request, EXECUTE_BEFORE_HEADER_PATTERN);
 
                     //Execute the sequences
-                    for (StepSequence sequence : preExecSequences) {
-                        sequence.executeBlocking();
+                    for (RequestSequenceInformation requestSequenceInformation : preExecSequences) {
+                        StepSequence sequence = requestSequenceInformation.sequence;
+                        Map<String, String> variables = requestSequenceInformation.variables;
+                        JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Execute sequence: " + sequence.getTitle() + ", with variables: " + variables.toString());
+                        sequence.executeBlocking(variables);
                     }
                 }
 
-                List<StepSequence> postExecSequences = extractExecSequencesFromRequest(requestInfo, EXECUTE_AFTER_HEADER_PATTERN);
+                List<RequestSequenceInformation> postExecSequences = extractExecSequencesFromRequest(requestInfo, EXECUTE_AFTER_HEADER_PATTERN);
 
                 if(postExecSequences.size() > 0){
                     //Remove the headers from the request
@@ -82,8 +88,19 @@ public class MessageProcessor implements IHttpListener {
 
                     //Joining the sequences as string to set them as a comment to catch them in the response
                     String postExecSequencesJoined = EXECUTE_AFTER_HEADER + ":";
-                    for (StepSequence sequence : postExecSequences) {
-                        postExecSequencesJoined += sequence.getTitle() + EXECUTE_AFTER_COMMENT_DELIMITER;
+                    for (RequestSequenceInformation requestSequenceInformation : postExecSequences) {
+                        StepSequence sequence = requestSequenceInformation.sequence;
+                        Map<String, String> variables = requestSequenceInformation.variables;
+                        String variableString = "";
+                        if (variables.size() > 0) {
+                            variableString += ":";
+                            for (Map.Entry<String, String> entry : variables.entrySet()) {
+                                variableString += entry.getKey() + "=";
+                                variableString += entry.getValue() + ";";
+                            }
+                        }
+
+                        postExecSequencesJoined += sequence.getTitle() + variableString + EXECUTE_AFTER_COMMENT_DELIMITER;
                     }
 
                     if(!postExecSequencesJoined.isEmpty()){
@@ -118,11 +135,14 @@ public class MessageProcessor implements IHttpListener {
                 messageInfo.setRequest(request);
             }else{
                 // this is a response so we check for the comments
-                List<StepSequence> postExecSequences = extractExecSequencesFromComment(messageInfo.getComment(), EXECUTE_AFTER_HEADER_PATTERN);
+                List<RequestSequenceInformation> postExecSequences = extractExecSequencesFromComment(messageInfo.getComment(), EXECUTE_AFTER_HEADER_PATTERN);
                 if(postExecSequences.size() > 0){
                     //Execute the sequences
-                    for (StepSequence sequence : postExecSequences) {
-                        sequence.executeBlocking();
+                    for (RequestSequenceInformation requestSequenceInformation : postExecSequences) {
+                        StepSequence sequence = requestSequenceInformation.sequence;
+                        Map<String, String> variables = requestSequenceInformation.variables;
+                        JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Execute sequence: " + sequence.getTitle() + ", with variables: " + variables.toString());
+                        sequence.executeBlocking(variables);
                     }
                     // remove the added comment from the request
                     messageInfo.setComment(messageInfo.getComment().replaceAll(EXECUTE_AFTER_REGEX+EXECUTE_AFTER_COMMENT_DELIMITER,""));
@@ -227,26 +247,33 @@ public class MessageProcessor implements IHttpListener {
         return Stepper.callbacks.getHelpers().buildHttpMessage(newRequestHeaders, newBody);
     }
 
-    public Map<String, String> extractVariablesFromStepperHeader(String headerValue) {
-        //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Extracting variable from: " + headerValue);
+    /**
+     * Extract all defined variables from the request sequence information string.
+     * 
+     * If a variable has more than one definition, the later one is used. 
+     * It expects the string to have a format that matches the definition in RequesteSequenceInformation.
+     * 
+     * For example, the string: `test: firstVariable=old; secondVariable=someValue; firstVariable=new`
+     * would be converted to a map with the following content:
+     * - firstVariable: new
+     * - secondVariable: someValue
+     * 
+     * @see RequestSequenceInformation
+     * @param sequenceInfoString The string that contains sequence information
+     * @return All defined variables
+     */
+    public Map<String, String> extractVariablesFromSequenceInfoString(String sequenceInfoString) {
         HashMap<String, String> map = new HashMap<>();
 
-        Pattern variableListPattern = Pattern.compile("\\w+(:\\s*(?<variables>.+))?", Pattern.CASE_INSENSITIVE);
-        Pattern variablePattern = Pattern.compile("(?<key>\\w+)=(?<value>[^;]+);?", Pattern.CASE_INSENSITIVE);
+        Matcher variableListMatcher = VARIABLE_LIST_PATTERN.matcher(sequenceInfoString);
 
-        Matcher variableListMatcher = variableListPattern.matcher(headerValue);
-
-        if (variableListMatcher.find()) {
+        if (variableListMatcher.find() && variableListMatcher.group("variables") != null) {
             String variableList = variableListMatcher.group("variables");
-            //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Variable list: " + variableList);
-
-            Matcher variablesMatcher = variablePattern.matcher(variableList);
+            Matcher variablesMatcher = VARIABLE_PATTERN.matcher(variableList);
 
             while (variablesMatcher.find()) {
                 String variableKey = variablesMatcher.group("key");
                 String variableValue = variablesMatcher.group("value");
-
-                //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Found variable key=" + variableKey + ", value=" + variableValue + ")");
 
                 map.put(variableKey, variableValue);
             }
@@ -256,17 +283,29 @@ public class MessageProcessor implements IHttpListener {
     }
 
     /**
+     * Extract a sequence's name from the request info string.
+     * @param sequenceInfoString String that contains the name and variables of a step sequence
+     * @return The sequence name
+     */
+    private Optional<String> extractSequenceNameFromSequenceInfoString(String sequenceInfoString) {
+        Matcher nameMatcher = STEPPER_SEQUENCE_NAME_PATTERN.matcher(sequenceInfoString);
+        if (!nameMatcher.find()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(nameMatcher.group(1).trim());
+    }
+
+    /**
      * Locates the X-Stepper-Execute-Before or X-Stepper-Execute-After headers and returns the matching sequences.
      * @param requestInfo
      * @param pattern
      * @return Optional value of step sequence to execute before or after the request.
      */
-    public List<StepSequence> extractExecSequencesFromRequest(IRequestInfo requestInfo, Pattern pattern){
+    public List<RequestSequenceInformation> extractExecSequencesFromRequest(IRequestInfo requestInfo, Pattern pattern){
         //Check if headers ask us to execute a request before the request.
         List<String> requestHeaders = requestInfo.getHeaders();
-        ArrayList<StepSequence> execSequences = new ArrayList<>();
-
-        Pattern namePattern = Pattern.compile("^([^:]+)(?::?)", Pattern.CASE_INSENSITIVE);
+        ArrayList<RequestSequenceInformation> execSequences = new ArrayList<>();
 
         for (Iterator<String> iterator = requestHeaders.iterator(); iterator.hasNext(); ) {
             String header = iterator.next();
@@ -279,17 +318,13 @@ public class MessageProcessor implements IHttpListener {
             ArrayList<StepSequence> currentSequences = new ArrayList<>();
             String stepperHeader = m.group(1).trim();
 
-            //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Stepper header:" + stepperHeader);
+            Optional<String> optionalName = this.extractSequenceNameFromSequenceInfoString(stepperHeader);
 
-            Matcher nameMatcher = namePattern.matcher(stepperHeader);
-            if (!nameMatcher.find()) {
-                //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not extract name");
+            if (optionalName.isEmpty()) {
                 continue;
             }
 
-            String sequenceName = nameMatcher.group(1);
-            //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Name is: " + sequenceName);
-
+            String sequenceName = optionalName.get();
 
             Optional<StepSequence> execSequence = sequenceManager.getSequences().stream()
                     .filter(sequence -> sequence.getTitle().equalsIgnoreCase(sequenceName))
@@ -301,21 +336,10 @@ public class MessageProcessor implements IHttpListener {
                 JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not find execution sequence named: \"" + sequenceName + "\".");
 
             // Extract variables and store them in the sequences
-            Map<String, String> arguments = extractVariablesFromStepperHeader(stepperHeader);
-            //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Extracted " + arguments.size() + " variables");
-            for (StepSequence sequence : currentSequences) {
-                //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Checked sequence " + sequence.getTitle() + ", has " + sequence.getGlobalVariableManager().getVariables().size() + " variables");
-                for (StepVariable variable : sequence.getGlobalVariableManager().getVariables()) {
-                    //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Test global variable " + variable.getIdentifier());
-                    if (arguments.containsKey(variable.getIdentifier())) {
-                        String value = arguments.get(variable.getIdentifier());
-                        variable.setValue(value);
-                    }
-                }
-            }
+            Map<String, String> arguments = extractVariablesFromSequenceInfoString(stepperHeader);
 
             for (StepSequence sequence : currentSequences) {
-                execSequences.add(sequence);
+                execSequences.add(new RequestSequenceInformation(sequence, arguments));
             }
         }
         return execSequences;
@@ -327,21 +351,31 @@ public class MessageProcessor implements IHttpListener {
      * @param pattern
      * @return Optional value of step sequence to execute after the request.
      */
-    public List<StepSequence> extractExecSequencesFromComment(String comment, Pattern pattern){
-        ArrayList<StepSequence> execSequences = new ArrayList<>();
+    public List<RequestSequenceInformation> extractExecSequencesFromComment(String comment, Pattern pattern){
+        ArrayList<RequestSequenceInformation> execSequences = new ArrayList<>();
         Matcher m = pattern.matcher(comment);
         if (m.find()) {
             String[] allSequences = m.group(1).split(EXECUTE_AFTER_COMMENT_DELIMITER);
-            for(String sequenceName : allSequences){
-                if(sequenceName != null && !sequenceName.isEmpty()){
+            for(String sequenceInfo : allSequences){
+                if(sequenceInfo != null && !sequenceInfo.isEmpty()){
+                    Optional<String> optionalName = this.extractSequenceNameFromSequenceInfoString(sequenceInfo);
+
+                    if (optionalName.isEmpty()) {
+                        continue;
+                    }
+
+                    String sequenceName = optionalName.get();
+
                     Optional<StepSequence> execSequence = sequenceManager.getSequences().stream()
-                            .filter(sequence -> sequence.getTitle().equalsIgnoreCase(sequenceName.trim()))
+                            .filter(sequence -> sequence.getTitle().equalsIgnoreCase(sequenceName))
                             .findFirst();
 
+                    Map<String, String> variables = this.extractVariablesFromSequenceInfoString(sequenceInfo);
+
                     if(execSequence.isPresent())
-                        execSequences.add(execSequence.get());
+                        execSequences.add(new RequestSequenceInformation(execSequence.get(), variables));
                     else
-                        JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not find execution sequence named: \"" + m.group(1).trim() + "\".");
+                        JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not find execution sequence named: \"" + sequenceInfo + "\".");
                 }
             }
         }

--- a/src/main/java/com/coreyd97/stepper/MessageProcessor.java
+++ b/src/main/java/com/coreyd97/stepper/MessageProcessor.java
@@ -75,7 +75,6 @@ public class MessageProcessor implements IHttpListener {
                     for (RequestSequenceInformation requestSequenceInformation : preExecSequences) {
                         StepSequence sequence = requestSequenceInformation.sequence;
                         Map<String, String> variables = requestSequenceInformation.variables;
-                        JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Execute sequence: " + sequence.getTitle() + ", with variables: " + variables.toString());
                         sequence.executeBlocking(variables);
                     }
                 }
@@ -141,7 +140,6 @@ public class MessageProcessor implements IHttpListener {
                     for (RequestSequenceInformation requestSequenceInformation : postExecSequences) {
                         StepSequence sequence = requestSequenceInformation.sequence;
                         Map<String, String> variables = requestSequenceInformation.variables;
-                        JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Execute sequence: " + sequence.getTitle() + ", with variables: " + variables.toString());
                         sequence.executeBlocking(variables);
                     }
                     // remove the added comment from the request

--- a/src/main/java/com/coreyd97/stepper/MessageProcessor.java
+++ b/src/main/java/com/coreyd97/stepper/MessageProcessor.java
@@ -315,14 +315,12 @@ public class MessageProcessor implements IHttpListener {
      * @return Map of all sequence arguments
      */
     private Map<String, String> extractSequenceArgumentsFromRequest(IRequestInfo requestInfo, Pattern pattern) {
-        Stepper.callbacks.printOutput("[MessageProcessor] extract arguments");        
         //Check if headers ask us to execute a request before the request.
         List<String> requestHeaders = requestInfo.getHeaders();
         Map<String, String> arguments = new HashMap<>();
 
         for (Iterator<String> iterator = requestHeaders.iterator(); iterator.hasNext(); ) {
             String header = iterator.next();
-            Stepper.callbacks.printOutput("[MessageProcessor] processing header: " + header);
 
             Matcher m = pattern.matcher(header);
             if (!m.matches()) {
@@ -331,18 +329,14 @@ public class MessageProcessor implements IHttpListener {
 
             String variableInfo = m.group(1).trim();
 
-            Stepper.callbacks.printOutput("[MessageProcessor] processing variable info: " + variableInfo);
 
             Matcher argumentMatcher = SINGLE_VARIABLE_PATTERN.matcher(variableInfo);
             if (!argumentMatcher.matches()) {
-                Stepper.callbacks.printOutput("[MessageProcessor] found variable header without value");
                 continue;
             }
 
             String variableKey = argumentMatcher.group("key");
             String variableValue = argumentMatcher.group("value");
-
-            Stepper.callbacks.printOutput("[MessageProcessor] got argument: " + variableKey + "=" + variableValue);
 
             arguments.put(variableKey, variableValue);
         }

--- a/src/main/java/com/coreyd97/stepper/MessageProcessor.java
+++ b/src/main/java/com/coreyd97/stepper/MessageProcessor.java
@@ -24,16 +24,20 @@ public class MessageProcessor implements IHttpListener {
     private final Preferences preferences;
     public static final String EXECUTE_BEFORE_HEADER = "X-Stepper-Execute-Before";
     public static final String EXECUTE_AFTER_HEADER = "X-Stepper-Execute-After";
+    public static final String EXECUTE_VAR_HEADER = "X-Stepper-Var";
     public static final String EXECUTE_BEFORE_REGEX = EXECUTE_BEFORE_HEADER + ":(.*)";
     public static final String EXECUTE_AFTER_REGEX = EXECUTE_AFTER_HEADER+":(.*)";
+    public static final String EXECUTE_VAR_REGEX = EXECUTE_VAR_HEADER + ":(.*)";
     public static final String EXECUTE_AFTER_COMMENT_DELIMITER = "#%~%#";
     public static final Pattern EXECUTE_BEFORE_HEADER_PATTERN = Pattern.compile("^" + EXECUTE_BEFORE_REGEX + "$", Pattern.CASE_INSENSITIVE);
     public static final Pattern EXECUTE_AFTER_HEADER_PATTERN = Pattern.compile("^" + EXECUTE_AFTER_REGEX + "$", Pattern.CASE_INSENSITIVE);
+    public static final Pattern EXECUTE_VAR_HEADER_PATTERN = Pattern.compile("^" + EXECUTE_VAR_REGEX + "$", Pattern.CASE_INSENSITIVE);
     public static final String STEPPER_IGNORE_HEADER = "X-Stepper-Ignore";
     public static final Pattern STEPPER_IGNORE_PATTERN = Pattern.compile("^"+STEPPER_IGNORE_HEADER, Pattern.CASE_INSENSITIVE);
     public static final Pattern STEPPER_SEQUENCE_NAME_PATTERN = Pattern.compile("^([^:]+)(?::?)", Pattern.CASE_INSENSITIVE);
-    public static final Pattern VARIABLE_LIST_PATTERN = Pattern.compile("\\w+(:\\s*(?<variables>.+))?", Pattern.CASE_INSENSITIVE);
-    public static final Pattern VARIABLE_PATTERN = Pattern.compile("(?<key>\\w+)=(?<value>[^;]+);?", Pattern.CASE_INSENSITIVE);
+    public static final Pattern VARIABLE_LIST_PATTERN = Pattern.compile("[^:]+(:\\s*(?<variables>.+))?", Pattern.CASE_INSENSITIVE);
+    public static final Pattern VARIABLE_PATTERN = Pattern.compile("(?<key>[^=]+)=(?<value>[^;]+);?", Pattern.CASE_INSENSITIVE);
+    public static final Pattern SINGLE_VARIABLE_PATTERN = Pattern.compile("(?<key>[^=]+)=(?<value>.*)", Pattern.CASE_INSENSITIVE);
 
     public MessageProcessor(SequenceManager sequenceManager, Preferences preferences){
         this.sequenceManager = sequenceManager;
@@ -65,7 +69,10 @@ public class MessageProcessor implements IHttpListener {
 
             if(messageIsRequest){
                 byte[] request = messageInfo.getRequest();
-                System.out.println("Request: " + messageInfo.getRequest());
+
+                // Extract variable headers from request
+                Map<String, String> sequenceArguments = extractSequenceArgumentsFromRequest(requestInfo, EXECUTE_VAR_HEADER_PATTERN);
+
                 List<RequestSequenceInformation> preExecSequences = extractExecSequencesFromRequest(requestInfo, EXECUTE_BEFORE_HEADER_PATTERN);
                 if(preExecSequences.size() > 0){
                     //Remove the headers from the request
@@ -75,7 +82,13 @@ public class MessageProcessor implements IHttpListener {
                     for (RequestSequenceInformation requestSequenceInformation : preExecSequences) {
                         StepSequence sequence = requestSequenceInformation.sequence;
                         Map<String, String> variables = requestSequenceInformation.variables;
-                        JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Execute sequence: " + sequence.getTitle() + ", with variables: " + variables.toString());
+
+                        // Merge arguments from variable headers into arguments for this sequence
+                        // Prioritize arguments specifically set for this sequence
+                        for (Map.Entry<String, String> entry : sequenceArguments.entrySet()) {
+                            variables.putIfAbsent(entry.getKey(), entry.getValue());
+                        }
+
                         sequence.executeBlocking(variables);
                     }
                 }
@@ -294,6 +307,48 @@ public class MessageProcessor implements IHttpListener {
         }
 
         return Optional.of(nameMatcher.group(1).trim());
+    }
+
+    /**
+     * Extract arguments from variable headers from the given request.
+     * @param requestInfo The request
+     * @param pattern Pattern used to identify variable header
+     * @return Map of all sequence arguments
+     */
+    private Map<String, String> extractSequenceArgumentsFromRequest(IRequestInfo requestInfo, Pattern pattern) {
+        Stepper.callbacks.printOutput("[MessageProcessor] extract arguments");        
+        //Check if headers ask us to execute a request before the request.
+        List<String> requestHeaders = requestInfo.getHeaders();
+        Map<String, String> arguments = new HashMap<>();
+
+        for (Iterator<String> iterator = requestHeaders.iterator(); iterator.hasNext(); ) {
+            String header = iterator.next();
+            Stepper.callbacks.printOutput("[MessageProcessor] processing header: " + header);
+
+            Matcher m = pattern.matcher(header);
+            if (!m.matches()) {
+                continue;
+            }
+
+            String variableInfo = m.group(1).trim();
+
+            Stepper.callbacks.printOutput("[MessageProcessor] processing variable info: " + variableInfo);
+
+            Matcher argumentMatcher = SINGLE_VARIABLE_PATTERN.matcher(variableInfo);
+            if (!argumentMatcher.matches()) {
+                Stepper.callbacks.printOutput("[MessageProcessor] found variable header without value");
+                continue;
+            }
+
+            String variableKey = argumentMatcher.group("key");
+            String variableValue = argumentMatcher.group("value");
+
+            Stepper.callbacks.printOutput("[MessageProcessor] got argument: " + variableKey + "=" + variableValue);
+
+            arguments.put(variableKey, variableValue);
+        }
+
+        return arguments;
     }
 
     /**

--- a/src/main/java/com/coreyd97/stepper/MessageProcessor.java
+++ b/src/main/java/com/coreyd97/stepper/MessageProcessor.java
@@ -1,10 +1,12 @@
 package com.coreyd97.stepper;
 
 import burp.*;
+
 import com.coreyd97.BurpExtenderUtilities.Preferences;
 import com.coreyd97.stepper.sequence.StepSequence;
 import com.coreyd97.stepper.sequencemanager.SequenceManager;
 import com.coreyd97.stepper.util.ReplacingInputStream;
+import com.coreyd97.stepper.variable.PreExecutionStepVariable;
 import com.coreyd97.stepper.variable.StepVariable;
 
 import javax.swing.*;
@@ -225,6 +227,34 @@ public class MessageProcessor implements IHttpListener {
         return Stepper.callbacks.getHelpers().buildHttpMessage(newRequestHeaders, newBody);
     }
 
+    public Map<String, String> extractVariablesFromStepperHeader(String headerValue) {
+        //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Extracting variable from: " + headerValue);
+        HashMap<String, String> map = new HashMap<>();
+
+        Pattern variableListPattern = Pattern.compile("\\w+(:\\s*(?<variables>.+))?", Pattern.CASE_INSENSITIVE);
+        Pattern variablePattern = Pattern.compile("(?<key>\\w+)=(?<value>[^;]+);?", Pattern.CASE_INSENSITIVE);
+
+        Matcher variableListMatcher = variableListPattern.matcher(headerValue);
+
+        if (variableListMatcher.find()) {
+            String variableList = variableListMatcher.group("variables");
+            //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Variable list: " + variableList);
+
+            Matcher variablesMatcher = variablePattern.matcher(variableList);
+
+            while (variablesMatcher.find()) {
+                String variableKey = variablesMatcher.group("key");
+                String variableValue = variablesMatcher.group("value");
+
+                //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Found variable key=" + variableKey + ", value=" + variableValue + ")");
+
+                map.put(variableKey, variableValue);
+            }
+        }
+
+        return map;
+    }
+
     /**
      * Locates the X-Stepper-Execute-Before or X-Stepper-Execute-After headers and returns the matching sequences.
      * @param requestInfo
@@ -236,18 +266,56 @@ public class MessageProcessor implements IHttpListener {
         List<String> requestHeaders = requestInfo.getHeaders();
         ArrayList<StepSequence> execSequences = new ArrayList<>();
 
+        Pattern namePattern = Pattern.compile("^([^:]+)(?::?)", Pattern.CASE_INSENSITIVE);
+
         for (Iterator<String> iterator = requestHeaders.iterator(); iterator.hasNext(); ) {
             String header = iterator.next();
-            Matcher m = pattern.matcher(header);
-            if (m.matches()) {
-                Optional<StepSequence> execSequence = sequenceManager.getSequences().stream()
-                        .filter(sequence -> sequence.getTitle().equalsIgnoreCase(m.group(1).trim()))
-                        .findFirst();
 
-                if(execSequence.isPresent())
-                    execSequences.add(execSequence.get());
-                else
-                    JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not find execution sequence named: \"" + m.group(1).trim() + "\".");
+            Matcher m = pattern.matcher(header);
+            if (!m.matches()) {
+                continue;
+            }
+
+            ArrayList<StepSequence> currentSequences = new ArrayList<>();
+            String stepperHeader = m.group(1).trim();
+
+            //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Stepper header:" + stepperHeader);
+
+            Matcher nameMatcher = namePattern.matcher(stepperHeader);
+            if (!nameMatcher.find()) {
+                //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not extract name");
+                continue;
+            }
+
+            String sequenceName = nameMatcher.group(1);
+            //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Name is: " + sequenceName);
+
+
+            Optional<StepSequence> execSequence = sequenceManager.getSequences().stream()
+                    .filter(sequence -> sequence.getTitle().equalsIgnoreCase(sequenceName))
+                    .findFirst();
+
+            if(execSequence.isPresent())
+                currentSequences.add(execSequence.get());
+            else
+                JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not find execution sequence named: \"" + sequenceName + "\".");
+
+            // Extract variables and store them in the sequences
+            Map<String, String> arguments = extractVariablesFromStepperHeader(stepperHeader);
+            //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Extracted " + arguments.size() + " variables");
+            for (StepSequence sequence : currentSequences) {
+                //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Checked sequence " + sequence.getTitle() + ", has " + sequence.getGlobalVariableManager().getVariables().size() + " variables");
+                for (StepVariable variable : sequence.getGlobalVariableManager().getVariables()) {
+                    //JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Test global variable " + variable.getIdentifier());
+                    if (arguments.containsKey(variable.getIdentifier())) {
+                        String value = arguments.get(variable.getIdentifier());
+                        variable.setValue(value);
+                    }
+                }
+            }
+
+            for (StepSequence sequence : currentSequences) {
+                execSequences.add(sequence);
             }
         }
         return execSequences;

--- a/src/main/java/com/coreyd97/stepper/MessageProcessor.java
+++ b/src/main/java/com/coreyd97/stepper/MessageProcessor.java
@@ -26,7 +26,7 @@ public class MessageProcessor implements IHttpListener {
     private final Preferences preferences;
     public static final String EXECUTE_BEFORE_HEADER = "X-Stepper-Execute-Before";
     public static final String EXECUTE_AFTER_HEADER = "X-Stepper-Execute-After";
-    public static final String EXECUTE_VAR_HEADER = "X-Stepper-Var";
+    public static final String EXECUTE_VAR_HEADER = "X-Stepper-Argument";
     public static final String EXECUTE_BEFORE_REGEX = EXECUTE_BEFORE_HEADER + ":(.*)";
     public static final String EXECUTE_AFTER_REGEX = EXECUTE_AFTER_HEADER+":(.*)";
     public static final String EXECUTE_VAR_REGEX = EXECUTE_VAR_HEADER + ":(.*)";

--- a/src/main/java/com/coreyd97/stepper/MessageProcessor.java
+++ b/src/main/java/com/coreyd97/stepper/MessageProcessor.java
@@ -8,6 +8,8 @@ import com.coreyd97.stepper.sequencemanager.SequenceManager;
 import com.coreyd97.stepper.util.ReplacingInputStream;
 import com.coreyd97.stepper.variable.PreExecutionStepVariable;
 import com.coreyd97.stepper.variable.StepVariable;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 import javax.swing.*;
 import java.io.ByteArrayInputStream;
@@ -99,25 +101,28 @@ public class MessageProcessor implements IHttpListener {
                     //Remove the headers from the request
                     request = removeHeaderMatchingPattern(request, EXECUTE_AFTER_HEADER_PATTERN);
 
+                    HashMap<String, Map<String, String>> allSequences = new HashMap<>();
+
                     //Joining the sequences as string to set them as a comment to catch them in the response
                     String postExecSequencesJoined = EXECUTE_AFTER_HEADER + ":";
                     for (RequestSequenceInformation requestSequenceInformation : postExecSequences) {
                         StepSequence sequence = requestSequenceInformation.sequence;
                         Map<String, String> variables = requestSequenceInformation.variables;
-                        String variableString = "";
-                        if (variables.size() > 0) {
-                            variableString += ":";
-                            for (Map.Entry<String, String> entry : variables.entrySet()) {
-                                variableString += entry.getKey() + "=";
-                                variableString += entry.getValue() + ";";
-                            }
+
+                        // Merge arguments from variable headers into arguments for this sequence
+                        // Prioritize arguments specifically set for this sequence
+                        for (Map.Entry<String, String> entry : sequenceArguments.entrySet()) {
+                            variables.putIfAbsent(entry.getKey(), entry.getValue());
                         }
 
-                        postExecSequencesJoined += sequence.getTitle() + variableString + EXECUTE_AFTER_COMMENT_DELIMITER;
+                        allSequences.put(sequence.getTitle(), variables);
                     }
 
+                    Gson gson = new Gson();
+                    String serializedSequences = gson.toJson(allSequences);
+
                     if(!postExecSequencesJoined.isEmpty()){
-                        messageInfo.setComment(messageInfo.getComment() + postExecSequencesJoined);
+                        messageInfo.setComment(messageInfo.getComment() + EXECUTE_AFTER_HEADER + ":" + serializedSequences);
                     }
                 }
 
@@ -403,28 +408,24 @@ public class MessageProcessor implements IHttpListener {
         ArrayList<RequestSequenceInformation> execSequences = new ArrayList<>();
         Matcher m = pattern.matcher(comment);
         if (m.find()) {
-            String[] allSequences = m.group(1).split(EXECUTE_AFTER_COMMENT_DELIMITER);
-            for(String sequenceInfo : allSequences){
-                if(sequenceInfo != null && !sequenceInfo.isEmpty()){
-                    Optional<String> optionalName = this.extractSequenceNameFromSequenceInfoString(sequenceInfo);
+            String allSequencesSerialized = m.group(1);
+            Gson gson = new Gson();
+            TypeToken<HashMap<String, HashMap<String, String>>> mapType = new TypeToken<HashMap<String, HashMap<String, String>>>(){};
+            HashMap<String, HashMap<String, String>> allSequences = gson.fromJson(allSequencesSerialized, mapType.getType());
 
-                    if (optionalName.isEmpty()) {
-                        continue;
-                    }
+            for(Map.Entry<String, HashMap<String, String>> entry : allSequences.entrySet()){
+                String sequenceName = entry.getKey();
 
-                    String sequenceName = optionalName.get();
+                Optional<StepSequence> execSequence = sequenceManager.getSequences().stream()
+                        .filter(sequence -> sequence.getTitle().equalsIgnoreCase(sequenceName))
+                        .findFirst();
 
-                    Optional<StepSequence> execSequence = sequenceManager.getSequences().stream()
-                            .filter(sequence -> sequence.getTitle().equalsIgnoreCase(sequenceName))
-                            .findFirst();
+                Map<String, String> variables = entry.getValue();
 
-                    Map<String, String> variables = this.extractVariablesFromSequenceInfoString(sequenceInfo);
-
-                    if(execSequence.isPresent())
-                        execSequences.add(new RequestSequenceInformation(execSequence.get(), variables));
-                    else
-                        JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not find execution sequence named: \"" + sequenceInfo + "\".");
-                }
+                if(execSequence.isPresent())
+                    execSequences.add(new RequestSequenceInformation(execSequence.get(), variables));
+                else
+                    JOptionPane.showMessageDialog(Stepper.getUI().getUiComponent(), "Could not find execution sequence named: \"" + sequenceName + "\".");
             }
         }
 

--- a/src/main/java/com/coreyd97/stepper/RequestSequenceInformation.java
+++ b/src/main/java/com/coreyd97/stepper/RequestSequenceInformation.java
@@ -1,0 +1,43 @@
+package com.coreyd97.stepper;
+
+import java.util.Map;
+
+import com.coreyd97.stepper.sequence.StepSequence;
+
+/**
+ * Holds information about a step sequence as defined in a request with the stepper headers.
+ * Includes information about all defined variables.
+ * 
+ * This information is stored either in the request's X-Stepper-Execute-Before and X-Steper-Execute-After header
+ * as well in the user comments in the following format:
+ * <sequence_name>: (<key>=<value>;)*
+ * 
+ * Here some examples to demonstrate how the string representation of this looks like:
+ * <pre>
+ * - `simpleExample: first=value`
+ *  - Name: simpleExample
+ *  - Variables:
+ *      first: value
+ * - `advancedExample: firstKey=firstValue;secondKey=secondValue; firstKey=overwrittenValue;`
+ *  - Name: advancedExample
+ *  - Variables:
+ *      firstKey: overwrittenValue
+ *      secondKey: secondValue
+ * </pre>
+ */
+class RequestSequenceInformation {
+    /**
+     * Defines step sequence.
+     */
+    public StepSequence sequence;
+
+    /**
+     * All variables for the sequence as defined in the stepper header.
+     */
+    public Map<String, String> variables;
+
+    public RequestSequenceInformation(StepSequence sequence, Map<String, String> variables) {
+        this.sequence = sequence;
+        this.variables = variables;
+    }
+}

--- a/src/main/java/com/coreyd97/stepper/about/view/AboutPanel.java
+++ b/src/main/java/com/coreyd97/stepper/about/view/AboutPanel.java
@@ -162,7 +162,23 @@ public class AboutPanel extends JPanel {
                     "as usual, and add the headers ";
             String stepExecutionUsageItalics = "\"X-Stepper-Execute-Before: SEQUENCENAME\", \"X-Stepper-Execute-After: SEQUENCENAME\"";
             String stepExecutionUsageB = " to the request respectively. This will cause the sequence to be executed and variables " +
-                    "to be updated every time the request is sent.";
+                    "to be updated every time the request is sent.\n\n";
+
+            String sequenceInputHeader = "Passing Arguments to Sequences:\n";
+            String sequenceInputUsageA = "It is possible to pass arguments to sequences. " +
+                    "This is helpful if the sequences before or after the execution of a request must contain some dynamic value that must match with the request itself. "+
+                    "In combination with other tools such as intruder or active scanner, this also allows testing more complex sequences and pass the tool's payload into the sequences.\n" +
+                    "Before you can pass arguments, you must first define a global variable for a sequence with your desired name. " +
+                    "The arguments are based on the global variables of a sequence and use the same names. If an argument is passed to the sequence, the value will override the global's value in the sequence. "+
+                    "There are two ways you can pass an argument.\n\n" +
+                    "1. Option: Execute before and after header:\n" +
+                    "You can pass the arguments in the stepper headers as shown below. You can pass a single argument or multiple arguments at once. The only limitation of this approach is that you can't pass the character \";\" as a value as it is used as the delimiter.\n";
+            String sequenceInputUsageBItalics = "\"X-Stepper-Execute-Before: SEQUENCENAME: arg1=value1\" or \"X-Stepper-Execute-After: SEQUENCENAME: arg1=value1; arg2=value2\"\n\n";
+            String sequenceInputUsageC = "2. Option: Argument header:\n" +
+                    "If there is the need to pass a semicolon or you are using payloads from another tool where the semicolon might be used, you can use a dedicated header to pass the argument." +
+                    "This header allows you to use any value as an argument but you can only set one argument per header. If you want to pass multiple arguments you have to use multiple headers." +
+                    "You can use this option as shown below:\n";
+            String sequenceInputUsageDItalics = "\"X-Stepper-Argument: var=value\"";
 
 //            aboutContent.getDocument().insertString(aboutContent.getText().length(), intro, italics);
 //            aboutContent.getDocument().insertString(aboutContent.getText().length(), instructionsHeader, bold);
@@ -178,13 +194,24 @@ public class AboutPanel extends JPanel {
             
             //Doing this an odd way since insertString seems to cause errors on windows!
             int offset = 0;
-            String[] sections = new String[]{intro, instructionsHeader, instructions, variableHelpHeader, variableHelp
-                    , regularExpressionHeader, regularExpressionHelp, regularExpressionExampleHeader
-                    , regularExpressionExample, variableUsageHeader, variableInsertion, variableExampleSequenceTitle, variableExampleSequenceUsage
-                    , variableExampleToolTitle, variableExampleToolUsage, stepExecutionHeader, stepExecutionUsageA,
-                    stepExecutionUsageItalics, stepExecutionUsageB};
-            Style[] styles = new Style[]{italics, bold, null, bold, null, bold, null, bold,
-                                            null, bold, null, null, italics, null, italics, bold, null, italics, null};
+            String[] sections = new String[]{
+                intro,
+                instructionsHeader, instructions,
+                variableHelpHeader, variableHelp,
+                regularExpressionHeader, regularExpressionHelp,
+                regularExpressionExampleHeader, regularExpressionExample,
+                variableUsageHeader, variableInsertion, variableExampleSequenceTitle, variableExampleSequenceUsage, variableExampleToolTitle, variableExampleToolUsage,
+                stepExecutionHeader, stepExecutionUsageA, stepExecutionUsageItalics, stepExecutionUsageB,
+                sequenceInputHeader, sequenceInputUsageA, sequenceInputUsageBItalics, sequenceInputUsageC, sequenceInputUsageDItalics};
+            Style[] styles = new Style[]{
+                italics,
+                bold, null,
+                bold, null,
+                bold, null,
+                bold, null,
+                bold, null, null, italics, null, italics,
+                bold, null, italics, null,
+                bold, null, italics, null, italics};
             String content = String.join("", sections);
             aboutContent.setText(content);
             for (int i = 0; i < sections.length; i++) {

--- a/src/main/java/com/coreyd97/stepper/sequence/StepSequence.java
+++ b/src/main/java/com/coreyd97/stepper/sequence/StepSequence.java
@@ -17,8 +17,10 @@ import com.coreyd97.stepper.variable.StepVariable;
 
 import javax.swing.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 public class StepSequence
@@ -42,11 +44,28 @@ public class StepSequence
         this("Step Sequence");
     }
 
-    public void executeBlocking(){
+    /**
+     * Execute the step sequence with a predefined list of global variables.
+     * 
+     * Variables are set in the synchronization block which should ensure that if the sequence
+     * has already been executed with another set of variable in between the extraction of the
+     * variables from the header or comment, it is still executed with this set of variables.
+     * @param newGlobalVariables Map of global variables
+     */
+    public void executeBlocking(Map<String, String> newGlobalVariables) {
         if(this.isExecuting) return; //Sequence already being executed.
         this.isExecuting = true;
         try {
             synchronized (StepSequence.this) {
+                // Assign variables to global variables
+                for (StepVariable variable : this.globalVariablesManager.getVariables()) {
+                    if (newGlobalVariables.containsKey(variable.getIdentifier())) {
+                        String newValue = newGlobalVariables.get(variable.getIdentifier());
+
+                        variable.setValue(newValue);
+                    }
+                }
+
                 StepSequenceTab tabUI = Stepper.getUI().getTabForStepManager(this);
                 SequenceContainer sequenceContainer = tabUI.getStepsContainer();
 
@@ -97,6 +116,10 @@ public class StepSequence
         }finally {
             this.isExecuting = false;
         }
+    }
+
+    public void executeBlocking(){
+        this.executeBlocking(new HashMap<>());
     }
 
     public void executeAsync(){


### PR DESCRIPTION
Hi @CoreyD97,

this PR would add the ability to pass arguments into sequences.
With the syntax `X-Stepper-Execute-Before: sequence: var1=value1; var2=value2` or a dedicated argument header `X-Stepper-Argument: var=value` this allows passing values into the sequence. The argument overrides the global variable of the sequence.

With this addition, some more complex and different request sequences can be tested with Stepper.  For example, I sometimes had the following behavior: One request creates some object based on the request's data. But the response does not include the created object. Another request only returns the previously created object.

Testing this behaviour is usually very annoying but with these changes this can be easily tested with Stepper.

1. Create sequence with the first request. Use global variables in request
2. Test the second request via Repeater, Intruder, Active Scanner, etc. and pass the payloads to the first request via the argument

I also added a short explaination of these changes to the About Tab.

Could you kindly review these changes and merge them if everything checks out.
This feature could be very nice.